### PR TITLE
UX improvements for timer configuration and display

### DIFF
--- a/ClimberTimer iOS/Info.plist
+++ b/ClimberTimer iOS/Info.plist
@@ -34,6 +34,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/ClimberTimer iOS/Views/ActiveTimerView.swift
+++ b/ClimberTimer iOS/Views/ActiveTimerView.swift
@@ -12,64 +12,68 @@ struct ActiveTimerView: View {
     }
 
     var body: some View {
-        ZStack {
-            // Background color based on phase
-            backgroundColor
-                .ignoresSafeArea()
-                .opacity(flashOpacity)
+        GeometryReader { geometry in
+            let isLandscape = geometry.size.width > geometry.size.height
 
-            VStack(spacing: 24) {
-                // Phase indicator
-                Text(timer.currentPhase.displayName)
-                    .font(.custom("AvenirNextCondensed-Bold", size: 34))
-                    .foregroundColor(.white)
+            ZStack {
+                // Background color based on phase
+                backgroundColor
+                    .ignoresSafeArea()
+                    .opacity(flashOpacity)
 
-                // Time remaining
-                Text(TimeFormatting.format(timer.timeRemaining))
-                    .font(Typography.timer)
-                    .foregroundColor(.white)
+                VStack(spacing: isLandscape ? 8 : 24) {
+                    // Phase indicator
+                    Text(timer.currentPhase.displayName)
+                        .font(.custom("AvenirNextCondensed-Bold", size: isLandscape ? 44 : 68))
+                        .foregroundColor(.white)
 
-                // Rep counter
-                Text("Rep \(timer.currentRep) of \(timer.totalReps)")
-                    .font(Typography.title3)
-                    .foregroundColor(.white.opacity(0.8))
+                    // Time remaining
+                    Text(TimeFormatting.format(timer.timeRemaining))
+                        .font(.custom("Menlo-Bold", size: isLandscape ? 60 : 80))
+                        .foregroundColor(.white)
 
-                Spacer()
+                    // Rep counter
+                    Text("Rep \(timer.currentRep) of \(timer.totalReps)")
+                        .font(Typography.title3)
+                        .foregroundColor(.white.opacity(0.8))
 
-                // Controls
-                HStack(spacing: 32) {
-                    // Reset button
-                    Button(action: { timer.reset() }) {
-                        Image(systemName: "arrow.counterclockwise")
-                            .font(.title)
-                            .foregroundColor(.white)
-                            .frame(width: 60, height: 60)
-                            .background(Color.white.opacity(0.2))
-                            .clipShape(Circle())
-                    }
+                    Spacer()
 
-                    // Play/Pause button
-                    Button(action: toggleTimer) {
-                        Image(systemName: timer.isRunning ? "pause.fill" : "play.fill")
-                            .font(.title)
-                            .foregroundColor(.white)
-                            .frame(width: 80, height: 80)
-                            .background(Color.white.opacity(0.3))
-                            .clipShape(Circle())
-                    }
+                    // Controls
+                    HStack(spacing: 32) {
+                        // Reset button
+                        Button(action: { timer.reset() }) {
+                            Image(systemName: "arrow.counterclockwise")
+                                .font(.title)
+                                .foregroundColor(.white)
+                                .frame(width: isLandscape ? 50 : 60, height: isLandscape ? 50 : 60)
+                                .background(Color.white.opacity(0.2))
+                                .clipShape(Circle())
+                        }
 
-                    // Close button
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                            .font(.title)
-                            .foregroundColor(.white)
-                            .frame(width: 60, height: 60)
-                            .background(Color.white.opacity(0.2))
-                            .clipShape(Circle())
+                        // Play/Pause button
+                        Button(action: toggleTimer) {
+                            Image(systemName: timer.isRunning ? "pause.fill" : "play.fill")
+                                .font(.title)
+                                .foregroundColor(.white)
+                                .frame(width: isLandscape ? 60 : 80, height: isLandscape ? 60 : 80)
+                                .background(Color.white.opacity(0.3))
+                                .clipShape(Circle())
+                        }
+
+                        // Close button
+                        Button(action: { dismiss() }) {
+                            Image(systemName: "xmark")
+                                .font(.title)
+                                .foregroundColor(.white)
+                                .frame(width: isLandscape ? 50 : 60, height: isLandscape ? 50 : 60)
+                                .background(Color.white.opacity(0.2))
+                                .clipShape(Circle())
+                        }
                     }
                 }
+                .padding()
             }
-            .padding()
         }
         .onAppear {
             timer.start()

--- a/ClimberTimer iOS/Views/DurationPickerView.swift
+++ b/ClimberTimer iOS/Views/DurationPickerView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct DurationPickerView: View {
+    @Binding var duration: TimeInterval
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var hours: Int = 0
+    @State private var minutes: Int = 0
+    @State private var seconds: Int = 0
+
+    let title: String
+
+    init(title: String, duration: Binding<TimeInterval>) {
+        self.title = title
+        self._duration = duration
+
+        let totalSeconds = Int(duration.wrappedValue)
+        _hours = State(initialValue: totalSeconds / 3600)
+        _minutes = State(initialValue: (totalSeconds % 3600) / 60)
+        _seconds = State(initialValue: totalSeconds % 60)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    // Hours
+                    VStack(spacing: 4) {
+                        Picker("Hours", selection: $hours) {
+                            ForEach(0..<24, id: \.self) { hour in
+                                Text("\(hour)")
+                                    .tag(hour)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(width: 80)
+                        .clipped()
+
+                        Text("hours")
+                            .font(.custom("AvenirNext-Regular", size: 13))
+                            .foregroundStyle(AppColors.granite.opacity(0.7))
+                    }
+
+                    // Minutes
+                    VStack(spacing: 4) {
+                        Picker("Minutes", selection: $minutes) {
+                            ForEach(0..<60, id: \.self) { minute in
+                                Text("\(minute)")
+                                    .tag(minute)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(width: 80)
+                        .clipped()
+
+                        Text("min")
+                            .font(.custom("AvenirNext-Regular", size: 13))
+                            .foregroundStyle(AppColors.granite.opacity(0.7))
+                    }
+
+                    // Seconds
+                    VStack(spacing: 4) {
+                        Picker("Seconds", selection: $seconds) {
+                            ForEach(0..<60, id: \.self) { second in
+                                Text("\(second)")
+                                    .tag(second)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                        .frame(width: 80)
+                        .clipped()
+
+                        Text("sec")
+                            .font(.custom("AvenirNext-Regular", size: 13))
+                            .foregroundStyle(AppColors.granite.opacity(0.7))
+                    }
+                }
+                .padding(.top, 20)
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+                ZStack {
+                    Image("Background")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .offset(x: -500)
+                    AppColors.tan.opacity(0.85)
+                }
+                .ignoresSafeArea()
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .font(.custom("AvenirNext-Regular", size: 17))
+                    .foregroundStyle(AppColors.granite)
+                }
+                ToolbarItem(placement: .principal) {
+                    Text(title)
+                        .font(.custom("AvenirNextCondensed-Bold", size: 20))
+                        .foregroundStyle(AppColors.darkBrown)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        duration = TimeInterval(hours * 3600 + minutes * 60 + seconds)
+                        dismiss()
+                    }
+                    .font(.custom("AvenirNext-DemiBold", size: 17))
+                    .foregroundStyle(AppColors.granite)
+                }
+            }
+        }
+    }
+}

--- a/ClimberTimer iOS/Views/RepsPickerView.swift
+++ b/ClimberTimer iOS/Views/RepsPickerView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct RepsPickerView: View {
+    @Binding var reps: Int
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedReps: Int
+
+    init(reps: Binding<Int>) {
+        self._reps = reps
+        _selectedReps = State(initialValue: reps.wrappedValue)
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker("Repetitions", selection: $selectedReps) {
+                    ForEach(1...20, id: \.self) { rep in
+                        Text("\(rep)")
+                            .tag(rep)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(height: 200)
+                .padding(.top, 20)
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+                ZStack {
+                    Image("Background")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .offset(x: -500)
+                    AppColors.tan.opacity(0.85)
+                }
+                .ignoresSafeArea()
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .font(.custom("AvenirNext-Regular", size: 17))
+                    .foregroundStyle(AppColors.granite)
+                }
+                ToolbarItem(placement: .principal) {
+                    Text("Repetitions")
+                        .font(.custom("AvenirNextCondensed-Bold", size: 20))
+                        .foregroundStyle(AppColors.darkBrown)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        reps = selectedReps
+                        dismiss()
+                    }
+                    .font(.custom("AvenirNext-DemiBold", size: 17))
+                    .foregroundStyle(AppColors.granite)
+                }
+            }
+        }
+    }
+}

--- a/ClimberTimer iOS/Views/TimerSetupView.swift
+++ b/ClimberTimer iOS/Views/TimerSetupView.swift
@@ -7,6 +7,9 @@ struct TimerSetupView: View {
     @Bindable var settingsViewModel: SettingsViewModel
     @State private var showingTimer = false
     @State private var showingSavePreset = false
+    @State private var showingWorkPicker = false
+    @State private var showingRestPicker = false
+    @State private var showingRepsPicker = false
     @State private var presetName = ""
     @State private var hasLoadedInitialInterval = false
     @State private var savedPresetName: String?
@@ -28,63 +31,57 @@ struct TimerSetupView: View {
             // Work Duration
             VStack {
                 Text("WORK")
-                    .font(.custom("AvenirNext-Regular", size: 15))
+                    .font(.custom("AvenirNext-Regular", size: 21))
                     .foregroundStyle(AppColors.granite.opacity(0.7))
-                HStack {
-                    Button("-") { if viewModel.workDuration > 1 { viewModel.workDuration -= 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
-                    Text("\(Int(viewModel.workDuration))s")
+                Button {
+                    showingWorkPicker = true
+                } label: {
+                    Text(formatDuration(viewModel.workDuration))
                         .font(.custom("Menlo-Bold", size: 35))
                         .foregroundStyle(AppColors.granite)
-                        .frame(minWidth: 80)
-                    Button("+") { if viewModel.workDuration < 60 { viewModel.workDuration += 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
+                        .frame(minWidth: 120)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background(AppColors.granite.opacity(0.1))
+                        .cornerRadius(8)
                 }
             }
 
             // Rest Duration
             VStack {
                 Text("REST")
-                    .font(.custom("AvenirNext-Regular", size: 15))
+                    .font(.custom("AvenirNext-Regular", size: 21))
                     .foregroundStyle(AppColors.granite.opacity(0.7))
-                HStack {
-                    Button("-") { if viewModel.restDuration > 1 { viewModel.restDuration -= 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
-                    Text("\(Int(viewModel.restDuration))s")
+                Button {
+                    showingRestPicker = true
+                } label: {
+                    Text(formatDuration(viewModel.restDuration))
                         .font(.custom("Menlo-Bold", size: 35))
                         .foregroundStyle(AppColors.granite)
-                        .frame(minWidth: 80)
-                    Button("+") { if viewModel.restDuration < 60 { viewModel.restDuration += 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
+                        .frame(minWidth: 120)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background(AppColors.granite.opacity(0.1))
+                        .cornerRadius(8)
                 }
             }
 
             // Repetitions
             VStack {
                 Text("REPS")
-                    .font(.custom("AvenirNext-Regular", size: 15))
+                    .font(.custom("AvenirNext-Regular", size: 21))
                     .foregroundStyle(AppColors.granite.opacity(0.7))
-                HStack {
-                    Button("-") { if viewModel.repetitions > 1 { viewModel.repetitions -= 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
+                Button {
+                    showingRepsPicker = true
+                } label: {
                     Text("\(viewModel.repetitions)")
                         .font(.custom("Menlo-Bold", size: 35))
                         .foregroundStyle(AppColors.granite)
-                        .frame(minWidth: 80)
-                    Button("+") { if viewModel.repetitions < 20 { viewModel.repetitions += 1 } }
-                        .foregroundStyle(AppColors.granite)
-                        .buttonStyle(.bordered)
-                        .tint(AppColors.granite)
+                        .frame(minWidth: 120)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background(AppColors.granite.opacity(0.1))
+                        .cornerRadius(8)
                 }
             }
 
@@ -175,12 +172,39 @@ struct TimerSetupView: View {
                 presetName = ""
             }
         }
+        .sheet(isPresented: $showingWorkPicker) {
+            DurationPickerView(title: "Work Duration", duration: $viewModel.workDuration)
+                .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showingRestPicker) {
+            DurationPickerView(title: "Rest Duration", duration: $viewModel.restDuration)
+                .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showingRepsPicker) {
+            RepsPickerView(reps: $viewModel.repetitions)
+                .presentationDetents([.medium])
+        }
         .onAppear {
             // Load initial interval when view appears (not in init, due to SwiftUI state issues)
             if !hasLoadedInitialInterval, let interval = initialInterval {
                 viewModel.loadPreset(interval)
                 hasLoadedInitialInterval = true
             }
+        }
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let totalSeconds = Int(duration)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else if minutes > 0 {
+            return String(format: "%d:%02d", minutes, seconds)
+        } else {
+            return String(format: "0:%02d", seconds)
         }
     }
 }

--- a/ClimberTimer.xcodeproj/project.pbxproj
+++ b/ClimberTimer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0057F012544EC510FB5702AF /* DurationPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6AA05E8C85126B4168CD2B /* DurationPickerView.swift */; };
 		13AC17E9BE56FF75F0145232 /* FeedbackSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CC0B4B80FD3F1DD602BBFE /* FeedbackSettingsTests.swift */; };
 		15E39D07CE143183B461957A /* IntervalTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A48A9BEB1D72CE5F22216C9 /* IntervalTimerTests.swift */; };
 		174E4E5C63E87E47DF4175EB /* TimerPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1670AF383C0813909E0B4D3B /* TimerPhase.swift */; };
@@ -18,6 +19,7 @@
 		313581DD4F804934F1322FA6 /* PresetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF238667267FD6E3065250A7 /* PresetStore.swift */; };
 		31CADB9C4AF2215849E1803A /* ActiveTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049785728AF3FB30D13279C /* ActiveTimerView.swift */; };
 		3BEE4B25C32BE867C5C0FEED /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44815C38B66CA0483084955E /* FeedbackSettings.swift */; };
+		46203F0D8F58CA270817BB21 /* RepsPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B01A02BA7E04876BD6C842F /* RepsPickerView.swift */; };
 		5996EA75E2392C245C8A1EED /* IntervalTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92038A8EBA13AB01D84798E /* IntervalTimer.swift */; };
 		5BA7CF414ABB50C8C0E5C678 /* ClimberTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D26E7C031F2BAF3F2EA2660 /* ClimberTimerTests.swift */; };
 		5C26C813019B10C930846627 /* LastUsedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79F0E37FA910F52F319BC66 /* LastUsedUITests.swift */; };
@@ -74,7 +76,9 @@
 		063252CCD86E1F2807C32AFE /* ClimberTimerWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimberTimerWatchApp.swift; sourceTree = "<group>"; };
 		1504680F560943987AB20286 /* PresetsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsViewModel.swift; sourceTree = "<group>"; };
 		1670AF383C0813909E0B4D3B /* TimerPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerPhase.swift; sourceTree = "<group>"; };
+		1B01A02BA7E04876BD6C842F /* RepsPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RepsPickerView.swift; sourceTree = "<group>"; };
 		2ABC17943849D22370525287 /* TimerPhaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerPhaseTests.swift; sourceTree = "<group>"; };
+		2B6AA05E8C85126B4168CD2B /* DurationPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurationPickerView.swift; sourceTree = "<group>"; };
 		2CD2632C584EE599B225E3AC /* FeedbackManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackManagerTests.swift; sourceTree = "<group>"; };
 		2D26E7C031F2BAF3F2EA2660 /* ClimberTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimberTimerTests.swift; sourceTree = "<group>"; };
 		32A4DA1EA5D9B48F51257105 /* ClimberTimerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClimberTimerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -234,6 +238,8 @@
 				BF10BDFAB787E71F62BE34A9 /* HomeView.swift */,
 				D33A597C831F998A89AE0BD4 /* SettingsView.swift */,
 				E5F20F758721D9A8EA306222 /* TimerSetupView.swift */,
+				2B6AA05E8C85126B4168CD2B /* DurationPickerView.swift */,
+				1B01A02BA7E04876BD6C842F /* RepsPickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -325,8 +331,6 @@
 			dependencies = (
 			);
 			name = "ClimberTimer Watch Watch App";
-			packageProductDependencies = (
-			);
 			productName = "ClimberTimer Watch Watch App";
 			productReference = ED801F12AEBEE2E55E77E0B7 /* ClimberTimer Watch Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -343,8 +347,6 @@
 			dependencies = (
 			);
 			name = ClimberTimer;
-			packageProductDependencies = (
-			);
 			productName = ClimberTimer;
 			productReference = B677E980FAFB33EE890B6998 /* ClimberTimer.app */;
 			productType = "com.apple.product-type.application";
@@ -361,8 +363,6 @@
 				050C5C901DBCC2DEC35F189F /* PBXTargetDependency */,
 			);
 			name = ClimberTimerUITests;
-			packageProductDependencies = (
-			);
 			productName = ClimberTimerUITests;
 			productReference = 32A4DA1EA5D9B48F51257105 /* ClimberTimerUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -379,8 +379,6 @@
 				89F63B7547BCAD488B16AB8A /* PBXTargetDependency */,
 			);
 			name = ClimberTimerTests;
-			packageProductDependencies = (
-			);
 			productName = ClimberTimerTests;
 			productReference = 95F81242CA4B5D016CD847B4 /* ClimberTimerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -409,6 +407,7 @@
 			);
 			mainGroup = FF644002E1E4448F7C44BF3B;
 			minimizedProjectReferenceProxies = 1;
+			productRefGroup = 64F01D0F3EB8ECDE2EA1BD8D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -507,6 +506,8 @@
 				943CD476A893E91678FE0B6E /* TimerSetupView.swift in Sources */,
 				TYPO0001A2B3C4D5E6F78901 /* Typography.swift in Sources */,
 				COLR0001A2B3C4D5E6F78901 /* Colors.swift in Sources */,
+				0057F012544EC510FB5702AF /* DurationPickerView.swift in Sources */,
+				46203F0D8F58CA270817BB21 /* RepsPickerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

- Add scrolling duration picker for work/rest times (hours, minutes, seconds) like Apple's Clock app
- Add scrolling reps picker (1-20)
- Increase WORK/REST/REPS heading font size to 21pt
- Double phase header size to 68pt on timer screen
- Add responsive layout for landscape orientation
- Add portrait upside down orientation support

## Test plan

- [ ] Tap work/rest duration to open scrolling picker
- [ ] Verify hours, minutes, seconds wheels work correctly
- [ ] Tap reps to open scrolling picker (1-20)
- [ ] Test timer screen in landscape mode
- [ ] Verify phase header scales appropriately in landscape

🤖 Generated with [Claude Code](https://claude.com/claude-code)