### PR TITLE
Set up TestFlight deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,21 @@ Carthage/Build
 
 # Worktrees
 .worktrees/
+
+# Ruby/Bundler
+vendor/bundle/
+.bundle/
+Gemfile.lock
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output/
+fastlane/README.md
+
+# Code signing (sensitive)
+*.p8
+*.p12
+*.mobileprovision
+*.provisionprofile

--- a/ClimberTimer Watch/Info.plist
+++ b/ClimberTimer Watch/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/ClimberTimer iOS/Info.plist
+++ b/ClimberTimer iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ClimberTimer.xcodeproj/project.pbxproj
+++ b/ClimberTimer.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -735,7 +735,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>upload</string>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>T3WWQ3395H</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "xcodeproj"

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,48 @@
+# Privacy Policy for Climber Timer
+
+**Last Updated: December 2024**
+
+## Overview
+
+Climber Timer ("the App") is developed by Snugglebearteam. This privacy policy explains how we handle information when you use our App.
+
+## Information We Collect
+
+**We do not collect any personal information.**
+
+The App operates entirely on your device and does not:
+- Collect personal data
+- Track your location
+- Access your contacts
+- Require account creation
+- Send data to external servers
+- Use analytics or tracking services
+
+## Data Storage
+
+All data created within the App (timer presets, settings) is stored locally on your device and synced via your personal iCloud account if enabled. We do not have access to this data.
+
+## Third-Party Services
+
+The App does not integrate with any third-party services, advertising networks, or analytics platforms.
+
+## Children's Privacy
+
+The App does not collect information from anyone, including children under 13 years of age.
+
+## Changes to This Policy
+
+We may update this privacy policy from time to time. We will notify you of any changes by posting the new privacy policy on this page and updating the "Last Updated" date.
+
+## Contact Us
+
+If you have questions about this privacy policy, please contact us by opening an issue at:
+https://github.com/britt/climbertimer/issues
+
+## Your Rights
+
+Since we don't collect any personal data, there is no personal information to access, modify, or delete. Your timer presets and settings are stored locally on your device and in your iCloud account, which you control.
+
+---
+
+A [Snugglebearteam](https://www.snugglebearteam.com/) Production

--- a/docs/TESTFLIGHT_SETUP.md
+++ b/docs/TESTFLIGHT_SETUP.md
@@ -1,0 +1,206 @@
+# TestFlight Deployment Guide
+
+This guide covers how to deploy Climber Timer to TestFlight for beta testing.
+
+## Prerequisites
+
+1. **Apple Developer Account** ($99/year)
+   - Enroll at [developer.apple.com](https://developer.apple.com)
+   - Enable two-factor authentication
+
+2. **App Store Connect Access**
+   - Create app records for iOS and watchOS
+   - Bundle IDs:
+     - iOS: `com.snugglebearteam.climbertimer.ios`
+     - watchOS: `com.snugglebearteam.climbertimer.watchkitapp`
+
+3. **Install Dependencies**
+   ```bash
+   bundle install
+   ```
+
+## App Store Connect Setup
+
+### 1. Create App Record
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com)
+2. Click "My Apps" → "+" → "New App"
+3. Fill in:
+   - Platform: iOS
+   - Name: Climber Timer
+   - Primary Language: English
+   - Bundle ID: Select from dropdown
+   - SKU: climber-timer-ios
+
+### 2. Configure App Privacy
+
+In App Store Connect → App Information → App Privacy:
+
+1. Click "Get Started" on privacy questionnaire
+2. For Climber Timer, select:
+   - **Data Not Collected** (we don't collect any user data)
+3. Save and submit
+
+### 3. Add Privacy Policy URL
+
+Add the privacy policy URL to:
+- App Store Connect → App Information → Privacy Policy URL
+
+Host the privacy policy at your domain or use GitHub Pages.
+
+## Local Deployment
+
+### Manual Build and Upload
+
+```bash
+# Build archive
+xcodebuild -scheme "ClimberTimer" \
+  -configuration Release \
+  -archivePath build/ClimberTimer.xcarchive \
+  archive
+
+# Export for App Store
+xcodebuild -exportArchive \
+  -archivePath build/ClimberTimer.xcarchive \
+  -exportOptionsPlist ExportOptions.plist \
+  -exportPath build/
+
+# Upload via Xcode Organizer or Transporter app
+```
+
+### Using Fastlane
+
+```bash
+# Run tests first
+bundle exec fastlane test
+
+# Build and upload to TestFlight
+bundle exec fastlane beta
+```
+
+## Fastlane Setup
+
+### First-Time Setup
+
+1. **Configure App Store Connect API Key**
+
+   Create an API key at App Store Connect → Users and Access → Keys:
+   - Download the .p8 key file
+   - Note the Key ID and Issuer ID
+
+2. **Set Environment Variables**
+   ```bash
+   export ASC_KEY_ID="your_key_id"
+   export ASC_ISSUER_ID="your_issuer_id"
+   export ASC_KEY_CONTENT=$(cat path/to/AuthKey.p8)
+   ```
+
+3. **Set Up Code Signing (Optional - for CI/CD)**
+   ```bash
+   # Initialize match for certificate management
+   bundle exec fastlane match init
+
+   # Create App Store certificates and profiles
+   bundle exec fastlane setup_certs
+   ```
+
+### Available Lanes
+
+| Lane | Description |
+|------|-------------|
+| `fastlane test` | Run unit tests |
+| `fastlane build` | Build release archive |
+| `fastlane beta` | Build and upload iOS app to TestFlight |
+| `fastlane beta_watch` | Build and upload watchOS app |
+| `fastlane beta_all` | Upload both iOS and watchOS |
+| `fastlane sync_certs` | Sync certificates (readonly) |
+| `fastlane setup_certs` | Create new certificates |
+
+## CI/CD with GitHub Actions
+
+Create `.github/workflows/testflight.yml`:
+
+```yaml
+name: TestFlight Deployment
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Build and upload to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: bundle exec fastlane beta
+```
+
+## TestFlight Testing
+
+### Internal Testing
+
+- Up to 100 internal testers (team members)
+- No App Review required
+- Immediate access to new builds
+
+### External Testing
+
+- Up to 10,000 external testers
+- Requires App Review for first build
+- 90-day build expiration
+
+### Adding Testers
+
+1. Go to App Store Connect → TestFlight
+2. Create test groups (Internal/External)
+3. Add testers by email
+4. Testers receive invitation to install TestFlight app
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"No signing certificate found"**
+   - Open Xcode → Preferences → Accounts
+   - Download certificates manually
+   - Or run `fastlane sync_certs`
+
+2. **"Provisioning profile doesn't match"**
+   - Delete old profiles in Xcode Preferences → Accounts
+   - Let Xcode automatically manage signing
+
+3. **"Build already exists"**
+   - Increment build number: `fastlane run increment_build_number`
+
+4. **"App Review rejection"**
+   - Check for crashes on launch
+   - Ensure privacy policy is accessible
+   - Review [App Store Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+
+## Version Management
+
+- **Version Number** (CFBundleShortVersionString): User-facing version (1.0.0)
+- **Build Number** (CFBundleVersion): Internal build identifier (42)
+
+Build number must increase with each TestFlight upload.
+
+---
+
+For more information, see [Apple's TestFlight documentation](https://developer.apple.com/testflight/).

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,12 @@
+# App Store Connect API Key
+# Set these environment variables or use app_store_connect_api_key action
+# ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_CONTENT
+
+# iOS App
+app_identifier("com.snugglebearteam.climbertimer")
+
+# Apple Developer Portal Team
+team_id("T3WWQ3395H")
+
+# App Store Connect Team (if different from Developer Portal)
+itc_team_id("T3WWQ3395H")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,96 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Build and upload to TestFlight"
+  lane :beta do
+    # Ensure we're on a clean state
+    ensure_git_status_clean unless ENV["SKIP_GIT_CHECK"]
+
+    # Increment build number
+    increment_build_number(
+      xcodeproj: "ClimberTimer.xcodeproj"
+    )
+
+    # Build the iOS app
+    build_app(
+      scheme: "ClimberTimer",
+      configuration: "Release",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "com.snugglebearteam.climbertimer" => "match AppStore com.snugglebearteam.climbertimer"
+        }
+      }
+    )
+
+    # Upload to TestFlight
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true
+    )
+
+    # Commit the version bump
+    commit_version_bump(
+      xcodeproj: "ClimberTimer.xcodeproj",
+      message: "Bump build number for TestFlight [skip ci]"
+    )
+
+    # Push to remote
+    push_to_git_remote
+  end
+
+  desc "Build and upload Watch app to TestFlight"
+  lane :beta_watch do
+    build_app(
+      scheme: "ClimberTimer Watch Watch App",
+      configuration: "Release",
+      export_method: "app-store",
+      destination: "generic/platform=watchOS"
+    )
+
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true
+    )
+  end
+
+  desc "Build both iOS and Watch apps for TestFlight"
+  lane :beta_all do
+    beta
+    beta_watch
+  end
+
+  desc "Run tests"
+  lane :test do
+    run_tests(
+      scheme: "ClimberTimer",
+      devices: ["iPhone 16"],
+      clean: true
+    )
+  end
+
+  desc "Build for local testing (no upload)"
+  lane :build do
+    build_app(
+      scheme: "ClimberTimer",
+      configuration: "Release",
+      export_method: "app-store",
+      skip_archive: false
+    )
+  end
+
+  desc "Sync certificates and provisioning profiles"
+  lane :sync_certs do
+    match(
+      type: "appstore",
+      app_identifier: ["com.snugglebearteam.climbertimer", "com.snugglebearteam.climbertimer.watchkitapp"],
+      readonly: true
+    )
+  end
+
+  desc "Create new certificates and provisioning profiles"
+  lane :setup_certs do
+    match(
+      type: "appstore",
+      app_identifier: ["com.snugglebearteam.climbertimer", "com.snugglebearteam.climbertimer.watchkitapp"]
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Add fastlane configuration for automated TestFlight builds
- Configure bundle ID and team settings for App Store Connect
- Set initial version to 0.1 and successfully uploaded to TestFlight
- Add privacy policy and setup documentation

## Test plan
- [x] Archive builds successfully
- [x] Export to App Store Connect works
- [x] Upload to TestFlight succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)