### PR TITLE
fix(modal): use explicit light colors for preset name TextField

### DIFF
--- a/ClimberTimer Watch/Info.plist
+++ b/ClimberTimer Watch/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ClimberTimer Widgets/Info.plist
+++ b/ClimberTimer Widgets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>0.3.1</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/ClimberTimer iOS/Info.plist
+++ b/ClimberTimer iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSSupportsLiveActivities</key>

--- a/Shared/Views/SavePresetSheet.swift
+++ b/Shared/Views/SavePresetSheet.swift
@@ -18,8 +18,16 @@ struct SavePresetSheet: View {
 
                 TextField("Preset Name", text: $presetName)
                     .font(.custom("AvenirNext-Medium", size: 17))
+                    .foregroundStyle(AppColors.granite)
                     #if os(iOS)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(.plain)
+                    .padding(12)
+                    .background(AppColors.warmWhite)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(AppColors.tan, lineWidth: 1)
+                    )
                     #endif
                     .padding(.horizontal)
 


### PR DESCRIPTION
Fixes visibility issue in the save preset modal by replacing the system `.roundedBorder` text field style with explicit custom styling using the app's color palette.

The TextField now uses `AppColors.granite` for text color and a warm white background with tan border, ensuring consistent visibility in all contexts.

Bumps version to 0.3.1 (build 8) across all targets.