### PR TITLE
chore: TestFlight configuration and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,16 @@ xcodebuild build -scheme "ClimberTimer Watch Watch App" -destination 'platform=w
 xcodebuild test -scheme "ClimberTimer" -destination 'platform=iOS Simulator,name=iPhone 16' -enableCodeCoverage YES
 ```
 
+## TestFlight Builds
+
+**When asked to upload a build to TestFlight, follow the instructions in [docs/testflight-upload.md](docs/testflight-upload.md).**
+
+Key points:
+- Use `xcodegen generate` to regenerate the project before building
+- Use `xcodebuild -exportArchive` with `-allowProvisioningUpdates` for upload
+- Authentication uses Xcode's stored credentials - no API keys needed
+- Do NOT use `fastlane upload_to_testflight` or `xcrun altool`
+
 ## Red Flags - STOP Immediately
 
 If you catch yourself:

--- a/ClimberTimer Watch/ClimberTimer Watch.entitlements
+++ b/ClimberTimer Watch/ClimberTimer Watch.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.climbertimer.shared</string>
+		<string>group.com.snugglebearteam.climbertimer</string>
 	</array>
 </dict>
 </plist>

--- a/ClimberTimer Watch/Info.plist
+++ b/ClimberTimer Watch/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ClimberTimer Widgets/Info.plist
+++ b/ClimberTimer Widgets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>0.3.1</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/ClimberTimer iOS/ClimberTimer.entitlements
+++ b/ClimberTimer iOS/ClimberTimer.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.climbertimer.shared</string>
+		<string>group.com.snugglebearteam.climbertimer</string>
 	</array>
 </dict>
 </plist>

--- a/ClimberTimer iOS/Info.plist
+++ b/ClimberTimer iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSSupportsLiveActivities</key>

--- a/ClimberTimer.xcodeproj/project.pbxproj
+++ b/ClimberTimer.xcodeproj/project.pbxproj
@@ -586,8 +586,21 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
+					152E0F83161CAFFFF17651C3 = {
+						DevelopmentTeam = T3WWQ3395H;
+					};
+					2186A00212E511AC5FF386B1 = {
+						DevelopmentTeam = T3WWQ3395H;
+					};
+					5D48B829EA240F4850E0DDE6 = {
+						DevelopmentTeam = T3WWQ3395H;
+					};
 					6C03E3E428A4BF708E8FBBD0 = {
+						DevelopmentTeam = T3WWQ3395H;
 						TestTargetID = 5D48B829EA240F4850E0DDE6;
+					};
+					FC3D2C4D961BFB4692F68727 = {
+						DevelopmentTeam = T3WWQ3395H;
 					};
 				};
 			};
@@ -798,7 +811,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ClimberTimer Watch/ClimberTimer Watch.entitlements";
 				INFOPLIST_FILE = "ClimberTimer Watch/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.watchkitapp;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
@@ -817,7 +830,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -858,6 +871,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = T3WWQ3395H;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -885,7 +899,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "ClimberTimer Widgets/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios.widgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.widgets;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -914,7 +928,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "ClimberTimer Widgets/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios.widgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.widgets;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -956,6 +970,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = T3WWQ3395H;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -996,7 +1011,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1042,7 +1057,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ClimberTimer Watch/ClimberTimer Watch.entitlements";
 				INFOPLIST_FILE = "ClimberTimer Watch/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = com.climbertimer.ios.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.snugglebearteam.climbertimer.watchkitapp;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;

--- a/Shared/Views/SavePresetSheet.swift
+++ b/Shared/Views/SavePresetSheet.swift
@@ -18,8 +18,16 @@ struct SavePresetSheet: View {
 
                 TextField("Preset Name", text: $presetName)
                     .font(.custom("AvenirNext-Medium", size: 17))
+                    .foregroundStyle(AppColors.granite)
                     #if os(iOS)
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(.plain)
+                    .padding(12)
+                    .background(AppColors.warmWhite)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(AppColors.tan, lineWidth: 1)
+                    )
                     #endif
                     .padding(.horizontal)
 

--- a/docs/testflight-upload.md
+++ b/docs/testflight-upload.md
@@ -1,0 +1,167 @@
+# TestFlight Upload Instructions
+
+This document describes the process for building and uploading ClimberTimer to TestFlight.
+
+## Prerequisites
+
+- Xcode with Apple ID signed in (Xcode → Settings → Accounts)
+- xcodegen installed (`brew install xcodegen`)
+- fastlane installed via bundler (`bundle install`)
+
+## Quick Reference
+
+```bash
+# 1. Regenerate project
+xcodegen generate
+
+# 2. Build for App Store
+SKIP_GIT_CHECK=true bundle exec fastlane run build_app scheme:"ClimberTimer" configuration:"Release" export_method:"app-store"
+
+# 3. Find the archive
+ARCHIVE=$(ls -td ~/Library/Developer/Xcode/Archives/$(date +%Y-%m-%d)/*.xcarchive | head -1)
+
+# 4. Create export options and upload
+cat > /tmp/ExportOptions.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>teamID</key>
+    <string>T3WWQ3395H</string>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE" \
+  -exportPath "build/export" \
+  -exportOptionsPlist /tmp/ExportOptions.plist \
+  -allowProvisioningUpdates
+
+# 5. Clean up build artifacts
+rm -f ClimberTimer.ipa ClimberTimer.app.dSYM.zip
+```
+
+## Detailed Steps
+
+### Step 1: Ensure project.yml is Configured
+
+The `project.yml` must have:
+
+```yaml
+settings:
+  SWIFT_VERSION: "5.9"
+  ENABLE_USER_SCRIPT_SANDBOXING: false
+  DEVELOPMENT_TEAM: T3WWQ3395H  # Required for signing
+```
+
+Bundle identifiers must match Apple Developer Portal:
+- Main app: `com.snugglebearteam.climbertimer`
+- Widgets: `com.snugglebearteam.climbertimer.widgets`
+- Watch: `com.snugglebearteam.climbertimer.watchkitapp`
+
+App group must be: `group.com.snugglebearteam.climbertimer`
+
+### Step 2: Regenerate Xcode Project
+
+```bash
+xcodegen generate
+```
+
+This regenerates `ClimberTimer.xcodeproj` from `project.yml` with the correct signing configuration.
+
+### Step 3: Build and Archive
+
+```bash
+SKIP_GIT_CHECK=true bundle exec fastlane run build_app \
+  scheme:"ClimberTimer" \
+  configuration:"Release" \
+  export_method:"app-store"
+```
+
+This:
+- Creates an archive at `~/Library/Developer/Xcode/Archives/YYYY-MM-DD/`
+- Exports `ClimberTimer.ipa` to the current directory
+- Creates `ClimberTimer.app.dSYM.zip` for crash symbolication
+
+### Step 4: Create ExportOptions.plist
+
+```bash
+cat > /tmp/ExportOptions.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>teamID</key>
+    <string>T3WWQ3395H</string>
+</dict>
+</plist>
+EOF
+```
+
+**Critical setting**: `destination: upload` tells xcodebuild to upload directly to App Store Connect.
+
+### Step 5: Export and Upload
+
+```bash
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE" \
+  -exportPath "build/export" \
+  -exportOptionsPlist /tmp/ExportOptions.plist \
+  -allowProvisioningUpdates
+```
+
+**Critical flag**: `-allowProvisioningUpdates` allows xcodebuild to use Xcode's stored Apple ID credentials. No separate API keys needed.
+
+Expected output:
+```
+Starting upload
+Progress 100%: Upload succeeded.
+Uploaded ClimberTimer
+** EXPORT SUCCEEDED **
+```
+
+### Step 6: Clean Up
+
+```bash
+rm -f ClimberTimer.ipa ClimberTimer.app.dSYM.zip
+```
+
+## Important Notes
+
+### Authentication
+- Uses Xcode's stored credentials (Xcode → Settings → Accounts)
+- No API keys, environment variables, or keychain configuration needed
+- The `-allowProvisioningUpdates` flag is what enables this
+
+### What NOT to Do
+- Don't use `fastlane upload_to_testflight` - requires separate API key configuration
+- Don't use `xcrun altool` - requires API key files in specific locations
+- Don't try passing API keys via environment variables
+- Don't use `fastlane beta` lane - it tries to increment build number which doesn't work with this project
+
+### Troubleshooting
+
+**"Signing requires a development team"**
+- Ensure `DEVELOPMENT_TEAM: T3WWQ3395H` is in project.yml settings
+- Run `xcodegen generate` to regenerate the project
+
+**"No profiles found for bundle ID"**
+- Bundle IDs in project.yml must match Apple Developer Portal exactly
+- Use `com.snugglebearteam.climbertimer`, not `com.climbertimer.ios`
+
+**"App Group not supported"**
+- App group must be `group.com.snugglebearteam.climbertimer`
+- Update both project.yml and the .entitlements files
+
+**Upload authentication fails**
+- Ensure Apple ID is signed in via Xcode → Settings → Accounts
+- The account must have access to the app in App Store Connect

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,7 @@ options:
 settings:
   SWIFT_VERSION: "5.9"
   ENABLE_USER_SCRIPT_SANDBOXING: false
+  DEVELOPMENT_TEAM: T3WWQ3395H
 
 targets:
   ClimberTimer:
@@ -19,14 +20,14 @@ targets:
       - path: ClimberTimer iOS
       - path: Shared
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: com.climbertimer.ios
+      PRODUCT_BUNDLE_IDENTIFIER: com.snugglebearteam.climbertimer
       INFOPLIST_FILE: ClimberTimer iOS/Info.plist
       CODE_SIGN_ENTITLEMENTS: ClimberTimer iOS/ClimberTimer.entitlements
     entitlements:
       path: ClimberTimer iOS/ClimberTimer.entitlements
       properties:
         com.apple.security.application-groups:
-          - group.com.climbertimer.shared
+          - group.com.snugglebearteam.climbertimer
     dependencies:
       - target: ClimberTimer Widgets
         embed: true
@@ -38,7 +39,7 @@ targets:
       - path: ClimberTimer Widgets
       - path: Shared
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: com.climbertimer.ios.widgets
+      PRODUCT_BUNDLE_IDENTIFIER: com.snugglebearteam.climbertimer.widgets
       INFOPLIST_FILE: ClimberTimer Widgets/Info.plist
       SKIP_INSTALL: true
       LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"
@@ -50,7 +51,7 @@ targets:
       - path: ClimberTimer Watch
       - path: Shared
     settings:
-      PRODUCT_BUNDLE_IDENTIFIER: com.climbertimer.ios.watchkitapp
+      PRODUCT_BUNDLE_IDENTIFIER: com.snugglebearteam.climbertimer.watchkitapp
       INFOPLIST_FILE: ClimberTimer Watch/Info.plist
       CODE_SIGN_ENTITLEMENTS: ClimberTimer Watch/ClimberTimer Watch.entitlements
       WATCHOS_DEPLOYMENT_TARGET: "10.0"
@@ -58,7 +59,7 @@ targets:
       path: ClimberTimer Watch/ClimberTimer Watch.entitlements
       properties:
         com.apple.security.application-groups:
-          - group.com.climbertimer.shared
+          - group.com.snugglebearteam.climbertimer
 
   ClimberTimerTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- Update bundle IDs and signing configuration to match Apple Developer Portal
- Add comprehensive TestFlight upload documentation

## Changes
- **project.yml**: Add DEVELOPMENT_TEAM, update bundle IDs to `com.snugglebearteam.*`
- **Entitlements**: Update app group to `group.com.snugglebearteam.climbertimer`
- **docs/testflight-upload.md**: Step-by-step TestFlight upload instructions
- **CLAUDE.md**: Link to TestFlight documentation

## Test plan
- [x] Build 8 (0.3.1) successfully uploaded to TestFlight
- [x] iOS and watchOS builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)