### PR TITLE
fix(ui): force light mode for consistent appearance

### DIFF
--- a/ClimberTimer Watch/App/ClimberTimerWatchApp.swift
+++ b/ClimberTimer Watch/App/ClimberTimerWatchApp.swift
@@ -19,6 +19,7 @@ struct ClimberTimerWatchApp: App {
     var body: some Scene {
         WindowGroup {
             WatchHomeView(presetStore: presetStore)
+                .preferredColorScheme(.light)
         }
         .modelContainer(modelContainer)
     }

--- a/ClimberTimer Watch/Info.plist
+++ b/ClimberTimer Watch/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ClimberTimer Widgets/Info.plist
+++ b/ClimberTimer Widgets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.1</string>
+    <string>0.3.2</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/ClimberTimer iOS/App/ClimberTimerApp.swift
+++ b/ClimberTimer iOS/App/ClimberTimerApp.swift
@@ -28,6 +28,7 @@ struct ClimberTimerApp: App {
             HomeView(presetStore: presetStore)
                 .environment(coordinator)
                 .tint(AppColors.granite)
+                .preferredColorScheme(.light)
         }
         .modelContainer(modelContainer)
     }

--- a/ClimberTimer iOS/Info.plist
+++ b/ClimberTimer iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSSupportsLiveActivities</key>


### PR DESCRIPTION
Force the app to always display in light mode by adding `.preferredColorScheme(.light)` to both iOS and watchOS app entry points. The app uses hardcoded light colors (warmWhite, chalk) that don't adapt to dark mode, causing inconsistent styling when system dark mode is enabled. This ensures a uniform, professional appearance regardless of user's system settings. Version bumped to 0.3.2 (build 9).